### PR TITLE
support passed-in config (overriding 'handler')

### DIFF
--- a/src/Support/Laravel/ServiceProvider.php
+++ b/src/Support/Laravel/ServiceProvider.php
@@ -36,9 +36,10 @@ class ServiceProvider extends BaseServiceProvider
     public function register()
     {
         // Configuring all guzzle clients.
-        $this->app->bind(ClientInterface::class, function () {
+        $this->app->bind(ClientInterface::class, function ($app, $params = []) {
+            $config = isset($params[0]) ? $params[0] : [];
             // Guzzle client
-            return new Client(['handler' => $this->app->make(HandlerStack::class)]);
+            return new Client($config + ['handler' => $this->app->make(HandlerStack::class)]);
         });
 
         $this->app->alias(ClientInterface::class, Client::class);


### PR DESCRIPTION
Laravel's make() function supports passing parameters to the constructor, which allows the user to configure Guzzle in various ways. This patch allows the Guzzle DebugBar ServiceProvider to pass through those options (with the exception of the 'handler' config option).
